### PR TITLE
js: fix mozc RuntimeError: indirect call signature mismatch !macos !windows !ios !harmony

### DIFF
--- a/patches/abseil-cpp.patch
+++ b/patches/abseil-cpp.patch
@@ -1,0 +1,44 @@
+diff --git a/absl/container/internal/raw_hash_set.cc b/absl/container/internal/raw_hash_set.cc
+index 9f4cefff..8a94d732 100644
+--- a/absl/container/internal/raw_hash_set.cc
++++ b/absl/container/internal/raw_hash_set.cc
+@@ -1284,7 +1284,7 @@ void IncrementSmallSize(CommonFields& common,
+ 
+ std::pair<ctrl_t*, void*> Grow1To3AndPrepareInsert(
+     CommonFields& common, const PolicyFunctions& __restrict policy,
+-    absl::FunctionRef<size_t(size_t)> get_hash) {
++    std::function<size_t(size_t)> get_hash) {
+   // TODO(b/413062340): Refactor to reuse more code with
+   // GrowSooTableToNextCapacityAndPrepareInsert.
+   ABSL_SWISSTABLE_ASSERT(common.capacity() == 1);
+@@ -1410,7 +1410,7 @@ size_t GrowToNextCapacityAndPrepareInsert(
+ 
+ std::pair<ctrl_t*, void*> PrepareInsertSmallNonSoo(
+     CommonFields& common, const PolicyFunctions& __restrict policy,
+-    absl::FunctionRef<size_t(size_t)> get_hash) {
++    std::function<size_t(size_t)> get_hash) {
+   ABSL_SWISSTABLE_ASSERT(common.is_small());
+   ABSL_SWISSTABLE_ASSERT(!policy.soo_enabled);
+   if (common.capacity() == 1) {
+diff --git a/absl/container/internal/raw_hash_set.h b/absl/container/internal/raw_hash_set.h
+index 679d68c4..21b5698c 100644
+--- a/absl/container/internal/raw_hash_set.h
++++ b/absl/container/internal/raw_hash_set.h
+@@ -1768,7 +1768,7 @@ size_t GrowSooTableToNextCapacityAndPrepareInsert(
+ // (is_small()==false).
+ std::pair<ctrl_t*, void*> PrepareInsertSmallNonSoo(
+     CommonFields& common, const PolicyFunctions& policy,
+-    absl::FunctionRef<size_t(size_t)> get_hash);
++    std::function<size_t(size_t)> get_hash);
+ 
+ // Resizes table with allocated slots and change the table seed.
+ // Tables with SOO enabled must have capacity > policy.soo_capacity.
+@@ -3248,7 +3248,7 @@ class raw_hash_set {
+     }
+     return {iterator_at_ptr(PrepareInsertSmallNonSoo(
+                 common(), GetPolicyFunctions(),
+-                HashKey<hasher, K, kIsDefaultHash>{hash_ref(), key})),
++                [this, &key](size_t x) { return HashKey<hasher, K, kIsDefaultHash>{hash_ref(), key}(x); })),
+             true};
+   }
+ 

--- a/scripts/libmozc.py
+++ b/scripts/libmozc.py
@@ -34,7 +34,6 @@ class MozcBuilder(CMakeBuilder):
 patch('libmozc/mozc/src/third_party/protobuf')
 
 if PLATFORM == 'js':
-    patch('libmozc/mozc')
     if platform.system() == 'Linux': # Nothing to steal so build it.
         build_dir = f'libmozc/build/linux-{platform.machine()}'
         ensure('cmake', [
@@ -47,6 +46,11 @@ if PLATFORM == 'js':
             '--target', 'protoc'
         ])
         protoc_exe = f'{ROOT}/{build_dir}/protoc'
+
+    # Disable thread.
+    patch('libmozc/mozc')
+    # Fix RuntimeError: null function or function signature mismatch.
+    patch('libmozc/mozc/src/third_party/abseil-cpp')
 
 if platform.system() == 'Darwin' and PLATFORM != 'macos':
     steal('libmozc', ('bin',)) # extracted to install dir so need to remove on prepack.


### PR DESCRIPTION
broken since https://github.com/abseil/abseil-cpp/commit/f0835ec75b44a6cc8959f582b99b4a6a0b4de0b3
browser throws on get_hash in Grow1To3AndPrepareInsert
change absl::FunctionRef to std::function works but I don't know why